### PR TITLE
cast printf variable for %lld

### DIFF
--- a/extension-functions.c
+++ b/extension-functions.c
@@ -1968,6 +1968,6 @@ int double_cmp(const void *a, const void *b){
 
 void print_elem(void *e, int64_t c, void* p){
   int ee = *(int*)(e);
-  printf("%d => %lld\n", ee,c);
+  printf("%d => %lld\n", ee,(long long int)c);
 }
 


### PR DESCRIPTION
I'm not sure if this will break the Windows compiles, but it clears up the warning for me on linux.
```
    [master]~/src/sqlite3-extension-functions>make
    gcc -fPIC -shared -o libsqlitefunctions.so extension-functions.c -lm
    extension-functions.c: In function ‘print_elem’:
    extension-functions.c:1971:20: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 3 has type ‘int64_t’ {aka ‘long int’} [-Wformat=]
     1971 |   printf("%d => %lld\n", ee,c);
          |                 ~~~^        ~
          |                    |        |
          |                    |        int64_t {aka long int}
          |                    long long int
          |                 %ld
```